### PR TITLE
Nuclear forces

### DIFF
--- a/openfermionpyscf/__init__.py
+++ b/openfermionpyscf/__init__.py
@@ -18,6 +18,7 @@ from ._pyscf_molecular_data import PyscfMolecularData
 
 from ._run_pyscf import (
         generate_molecular_hamiltonian,
+        generate_nuclear_forces,
         prepare_pyscf_molecule,
         run_pyscf)
 

--- a/openfermionpyscf/_nuclear_gradient_integrals.py
+++ b/openfermionpyscf/_nuclear_gradient_integrals.py
@@ -1,0 +1,112 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Helper functions for AO gradient tensors (core, eri, s) """
+
+import numpy as np
+from pyscf import gto
+
+
+def hcore_generator(mol: gto.Mole):
+    """Generator for the core deriv function
+
+    int1e_ipkin and int1e_ipnuc take the grad with respect to each
+    basis function's atomic position x, y, z and place in a matrix.
+    To get the gradient with respect to a particular atom we must
+    add the columns of basis functions associated
+    """
+    aoslices = mol.aoslice_by_atom()
+    h1 = mol.intor('int1e_ipkin', comp=3)  # (0.5 \nabla | p dot p | \)
+    h1 += mol.intor('int1e_ipnuc', comp=3)  # (\nabla | nuc | \)
+    h1 *= -1
+
+    def hcore_deriv(atm_id):
+        _, _, p0, p1 = aoslices[atm_id]
+        """this part gets the derivative with respect to the electron-nuc
+        operator. See pyscf docs for more info.
+        (p|Grad_{Ra}Sum(M) 1/r_{e} - R_{M}|q)
+        """
+        with mol.with_rinv_at_nucleus(atm_id):
+            vrinv = mol.intor('int1e_iprinv', comp=3)
+            vrinv *= -mol.atom_charge(atm_id)
+        vrinv[:, p0:p1] += h1[:, p0:p1]  # add the row's that aren't zero
+        return vrinv + vrinv.transpose(0, 2, 1)
+
+    return hcore_deriv
+
+
+def overlap_generator(mol: gto.Mole):
+    """Generator for the overlap derivfunction
+
+    int1e_ipovlp takes the grad of the overlap
+    with respect to each basis function's positions
+    """
+    aoslices = mol.aoslice_by_atom()
+    s1 = mol.intor('int1e_ipovlp', comp=3)  # (\nabla \| \)
+
+    def ovlp_deriv(atm_id):
+        s_r = np.zeros_like(s1)
+        _, _, p0, p1 = aoslices[atm_id]
+        # row-idx indexes basis function.  All basis functions not on
+        # a specific atom is zero.
+        s_r[:, p0:p1] = s1[:, p0:p1]
+        # (\nabla \| \ ) +  (\| \nabla)
+        return s_r + s_r.transpose((0, 2, 1))
+
+    return ovlp_deriv
+
+
+def eri_generator(mol: gto.Mole):
+    """Using int2e_ip1 = (nabla, | , )
+
+    Remeber: chem notation (1*,1|2*,2) -> (ij|kl)
+
+    NOTE: Prove the following is true through integral recursions
+
+    (nabla i,j|kl) = (j,nablai|k,l) = (k,l|nabla i,j) = (k,l|j,nabla i)
+    """
+    aoslices = mol.aoslice_by_atom()
+    eri_3 = mol.intor("int2e_ip1", comp=3)
+
+    def eri_deriv(atm_id):
+        eri_r = np.zeros_like(eri_3)
+        _, _, p0, p1 = aoslices[atm_id]
+        # take only the p0:p1 rows of the first index.
+        # note we leverage numpy taking over all remaining jkl indices.
+        # (p1 - p0, N, N, N) are non-zero
+        eri_r[:, p0:p1] = eri_3[:, p0:p1]
+        eri_r[:, :, p0:p1, :, :] += np.einsum('xijkl->xjikl', eri_3[:, p0:p1])
+        eri_r[:, :, :, p0:p1, :] += np.einsum('xijkl->xklij', eri_3[:, p0:p1])
+        eri_r[:, :, :, :, p0:p1] += np.einsum('xijkl->xklji', eri_3[:, p0:p1])
+        return eri_r
+
+    return eri_deriv
+
+
+def grad_nuc(mol: gto.Mole, atmlst=None):
+    '''
+    Derivatives of nuclear repulsion energy wrt nuclear coordinates
+
+    courtesy of pyscf and Szabo
+    '''
+    gs = np.zeros((mol.natm, 3))
+    for j in range(mol.natm):
+        q2 = mol.atom_charge(j)
+        r2 = mol.atom_coord(j)
+        for i in range(mol.natm):
+            if i != j:
+                q1 = mol.atom_charge(i)
+                r1 = mol.atom_coord(i)
+                r = np.sqrt(np.dot(r1-r2, r1-r2))
+                gs[j] -= q1 * q2 * (r2-r1) / r**3
+    if atmlst is not None:
+        gs = gs[atmlst]
+    return gs

--- a/openfermionpyscf/_pyscf_molecular_data.py
+++ b/openfermionpyscf/_pyscf_molecular_data.py
@@ -18,6 +18,8 @@ from pyscf import ao2mo
 from pyscf import scf
 from pyscf.cc.addons import spatial2spin
 from openfermion.chem import MolecularData
+from openfermion.chem.molecular_data import spinorb_from_spatial
+from openfermion.ops import InteractionOperator
 
 
 class PyscfMolecularData(MolecularData):
@@ -37,6 +39,8 @@ class PyscfMolecularData(MolecularData):
         MolecularData.__init__(self, geometry, basis, multiplicity,
                                charge, description, filename, data_directory)
         self._pyscf_data = {}
+        self._one_body_force_integrals = None
+        self._two_body_force_integrals = None
 
     @property
     def canonical_orbitals(self):
@@ -283,3 +287,60 @@ class PyscfMolecularData(MolecularData):
             self._ccsd_double_amps[no:,:no,no:,:no] = .5 * t2.transpose(2,0,3,1)
 
         return self._ccsd_double_amps
+
+    @property
+    def one_body_force_integrals(self):
+        """A 4-dimension array for the one-body part of the energy derivative
+        operator in the MO basis. The integrals are stored such that
+        f[i,j,...] are the one-body integrals of the force on atom i for
+        coordinate j.
+        """
+        if self._one_body_force_integrals is None:
+            forces = self._pyscf_data.get('forces', None)
+            if forces is None:
+                return None
+
+            self._one_body_force_integrals = forces['f1']
+
+        return self._one_body_force_integrals
+
+    @property
+    def two_body_force_integrals(self):
+        """A 6-dimension array for the two-body part of the energy derivative
+        operator in the MO basis. The integrals are stored such that
+        f[i,j,...] are the two-body integrals of the force on atom i in
+        coordinate j.
+        """
+        if self._two_body_force_integrals is None:
+            forces = self._pyscf_data.get('forces', None)
+            if forces is None:
+                return None
+
+            self._two_body_force_integrals = forces['f2']
+
+        return self._two_body_force_integrals
+
+    def get_nuclear_forces(self):
+        r"""Outputs the nuclear forces
+
+        Returns:
+            force_operators: a list of length number of atoms with lists of
+                3 InteractionOperators
+        """
+        force_operators = []
+        pyscf_mol = self._pyscf_data['mol']
+
+        for atom in range(pyscf_mol.natm):
+            force_vector = []
+            for coord in range(3):
+                one_body_coefficients, two_body_coefficients = \
+                    spinorb_from_spatial(
+                        self.one_body_force_integrals[atom, coord],
+                        self.two_body_force_integrals[atom, coord])
+
+                force_vector.append(InteractionOperator(
+                    0., one_body_coefficients, 1 / 2 * two_body_coefficients))
+
+            force_operators.append(force_vector)
+
+        return force_operators

--- a/openfermionpyscf/_pyscf_molecular_data.py
+++ b/openfermionpyscf/_pyscf_molecular_data.py
@@ -83,8 +83,8 @@ class PyscfMolecularData(MolecularData):
             n_orbitals = mo.shape[1]
 
             eri = ao2mo.kernel(mol, mo)
-            eri = ao2mo.restore(1, # no permutation symmetry
-                                eri, n_orbitals)
+            # No permutation symmetry
+            eri = ao2mo.restore(1, eri, n_orbitals)
             # See PQRS convention in OpenFermion.hamiltonians.molecular_data
             # h[p,q,r,s] = (ps|qr) = pyscf_eri[p,s,q,r]
             self._two_body_integrals = numpy.asarray(
@@ -266,14 +266,15 @@ class PyscfMolecularData(MolecularData):
             no, nv = t1.shape
             nmo = no + nv
             self._ccsd_single_amps = numpy.zeros((nmo, nmo))
-            self._ccsd_single_amps[no:,:no] = t1.T
+            self._ccsd_single_amps[no:, :no] = t1.T
 
         return self._ccsd_single_amps
 
     @property
     def ccsd_double_amps(self):
-        r"""A 4-dimension array t[a,i,b,j] for CCSD double excitation amplitudes
-        where a, b are virtual indices and i, j are occupied indices.
+        r"""A 4-dimension array t[a,i,b,j] for CCSD double excitation
+        amplitudes where a, b are virtual indices and i, j are occupied
+        indices.
         """
         if self._ccsd_double_amps is None:
             ccsd = self._pyscf_data.get('ccsd', None)
@@ -284,7 +285,8 @@ class PyscfMolecularData(MolecularData):
             no, nv = t2.shape[1:3]
             nmo = no + nv
             self._ccsd_double_amps = numpy.zeros((nmo, nmo, nmo, nmo))
-            self._ccsd_double_amps[no:,:no,no:,:no] = .5 * t2.transpose(2,0,3,1)
+            self._ccsd_double_amps[no:, :no, no:, :no] = \
+                .5 * t2.transpose(2, 0, 3, 1)
 
         return self._ccsd_double_amps
 

--- a/openfermionpyscf/_run_pyscf.py
+++ b/openfermionpyscf/_run_pyscf.py
@@ -87,9 +87,9 @@ def compute_integrals(pyscf_molecule, pyscf_scf):
     two_electron_compressed = ao2mo.kernel(pyscf_molecule,
                                            pyscf_scf.mo_coeff)
 
+    # No permutation symmetry
     two_electron_integrals = ao2mo.restore(
-        1, # no permutation symmetry
-        two_electron_compressed, n_orbitals)
+        1, two_electron_compressed, n_orbitals)
     # See PQRS convention in OpenFermion.hamiltonians._molecular_data
     # h[p,q,r,s] = (ps|qr)
     two_electron_integrals = numpy.asarray(
@@ -252,7 +252,7 @@ def generate_molecular_hamiltonian(
     # Run electronic structure calculations
     molecule = run_pyscf(
             MolecularData(
-                geometry, basis, multiplicity, charge, 
+                geometry, basis, multiplicity, charge,
                 data_directory=data_directory)
     )
 
@@ -273,6 +273,7 @@ def generate_molecular_hamiltonian(
     return molecule.get_molecular_hamiltonian(
             occupied_indices=occupied_indices,
             active_indices=active_indices)
+
 
 def calculate_force_integrals(
         pyscf_mol, pyscf_scf, atmlst=None, hcore_mo=None, tei_mo=None):

--- a/openfermionpyscf/_run_pyscf.py
+++ b/openfermionpyscf/_run_pyscf.py
@@ -227,7 +227,8 @@ def generate_molecular_hamiltonian(
         multiplicity,
         charge=0,
         n_active_electrons=None,
-        n_active_orbitals=None):
+        n_active_orbitals=None,
+        data_directory=None):
     """Generate a molecular Hamiltonian with the given properties.
 
     Args:
@@ -250,7 +251,9 @@ def generate_molecular_hamiltonian(
 
     # Run electronic structure calculations
     molecule = run_pyscf(
-            MolecularData(geometry, basis, multiplicity, charge)
+            MolecularData(
+                geometry, basis, multiplicity, charge, 
+                data_directory=data_directory)
     )
 
     # Freeze core orbitals and truncate to active space

--- a/openfermionpyscf/_run_pyscf.py
+++ b/openfermionpyscf/_run_pyscf.py
@@ -19,8 +19,10 @@ from functools import reduce
 import numpy
 from pyscf import gto, scf, ao2mo, ci, cc, fci, mp
 
-from openfermion import MolecularData
+from openfermion import MolecularData, general_basis_change
 from openfermionpyscf import PyscfMolecularData
+from ._nuclear_gradient_integrals import hcore_generator, \
+    eri_generator, overlap_generator
 
 
 def prepare_pyscf_molecule(molecule):
@@ -103,6 +105,7 @@ def run_pyscf(molecule,
               run_cisd=False,
               run_ccsd=False,
               run_fci=False,
+              forces=False,
               verbose=False):
     """
     This function runs a pyscf calculation.
@@ -114,6 +117,7 @@ def run_pyscf(molecule,
         run_cisd: Optional boolean to run CISD calculation.
         run_ccsd: Optional boolean to run CCSD calculation.
         run_fci: Optional boolean to FCI calculation.
+        forces: Optional boolean to get nuclear gradient matrix elements.
         verbose: Boolean whether to print calculation results to screen.
 
     Returns:
@@ -199,10 +203,21 @@ def run_pyscf(molecule,
             print('FCI energy for {} ({} electrons) is {}.'.format(
                 molecule.name, molecule.n_electrons, molecule.fci_energy))
 
+    # Get gradients
+    if forces:
+        one_body_force_integrals, \
+            two_body_force_integrals = calculate_force_integrals(
+                                        pyscf_molecule, pyscf_scf)
+        pyscf_data['forces'] = {'f1': one_body_force_integrals,
+                                'f2': two_body_force_integrals}
+        molecule._one_body_force_integrals = one_body_force_integrals
+        molecule._two_body_force_integrals = two_body_force_integrals
+
     # Return updated molecule instance.
     pyscf_molecular_data = PyscfMolecularData.__new__(PyscfMolecularData)
     pyscf_molecular_data.__dict__.update(molecule.__dict__)
     pyscf_molecular_data.save()
+
     return pyscf_molecular_data
 
 
@@ -255,3 +270,113 @@ def generate_molecular_hamiltonian(
     return molecule.get_molecular_hamiltonian(
             occupied_indices=occupied_indices,
             active_indices=active_indices)
+
+def calculate_force_integrals(
+        pyscf_mol, pyscf_scf, atmlst=None, hcore_mo=None, tei_mo=None):
+    r"""
+        Obtain gradient operator integrals in physicist ordering
+
+    Args:
+        pyscf_mol (pyscf.Mole): Object holding AO integrals.
+        pyscf_scf (pyscf.scf): SCF object holding the molecular orbital
+            coefficients.
+
+    Returns:
+        f1mos (ndarray): An N_a by 3 by N by N array storing the one-body
+            part of the force operators.
+        f2mos (ndarray): An N_a by 3 by N by N by N by N array storing the
+            two-body part of the force operators.
+    """
+    norbs = pyscf_mol.nao
+
+    hcore_deriv = hcore_generator(pyscf_mol)
+    ovrlp_deriv = overlap_generator(pyscf_mol)
+    eri_deriv = eri_generator(pyscf_mol)
+
+    if atmlst is None:
+        atmlst = range(pyscf_mol.natm)
+
+    if hcore_mo is None:
+        hcore_mo = general_basis_change(
+                    pyscf_mol.get_hcore(), pyscf_scf.mo_coeff, key=(1, 0)
+                    )
+
+    if tei_mo is None:
+        tei_mo_compressed = ao2mo.kernel(pyscf_mol, pyscf_scf.mo_coeff)
+        tei_mo = ao2mo.restore(1, tei_mo_compressed, norbs)
+
+    f1mos = numpy.zeros((len(atmlst), 3, norbs, norbs))
+    f2mos = numpy.zeros((len(atmlst), 3, norbs, norbs, norbs, norbs))
+
+    for k, ia in enumerate(atmlst):
+        h1ao = hcore_deriv(ia)
+        s1ao = ovrlp_deriv(ia)
+        eriao = eri_deriv(ia)
+        s1mo = numpy.zeros_like(s1ao)
+
+        for xyz in range(3):
+            # Core-MO - Hellmann-Feynman term
+            f1mos[k, xyz] = general_basis_change(
+                            h1ao[xyz], pyscf_scf.mo_coeff, key=(1, 0)
+                            )
+
+            # X-S-MO
+            s1mo[xyz] = general_basis_change(
+                            s1ao[xyz], pyscf_scf.mo_coeff, key=(1, 0)
+                            )
+
+            # one-body part of wavefunction force
+            f1mos[k, xyz] += 0.5 * (
+                            numpy.einsum('pj,ip->ij', hcore_mo, s1mo[xyz]) +
+                            numpy.einsum('ip,jp->ij', hcore_mo, s1mo[xyz])
+                            )
+
+            # eriao in openfermion ordering Hellmann-Feynman term
+            f2mos[k, xyz] -= general_basis_change(
+                                eriao[xyz], pyscf_scf.mo_coeff,
+                                key=(1, 0, 1, 0)
+                                ).transpose((0, 2, 3, 1))
+
+            # two-body part of wavefunction force
+            f2mos[k, xyz] += 0.5 * (
+                                numpy.einsum('px,xqrs', s1mo[xyz], tei_mo) +
+                                numpy.einsum('qx,pxrs', s1mo[xyz], tei_mo) +
+                                numpy.einsum('rx,pqxs', s1mo[xyz], tei_mo) +
+                                numpy.einsum('sx,pqrx', s1mo[xyz], tei_mo)
+                                )
+
+    return f1mos, f2mos
+
+
+def generate_nuclear_forces(
+        geometry,
+        basis,
+        multiplicity,
+        charge=0,
+        data_directory=None):
+    """Generate nuclear gradient operators.
+
+    Args:
+        geometry: A list of tuples giving the coordinates of each atom.
+            An example is [('H', (0, 0, 0)), ('H', (0, 0, 0.7414))].
+            Distances in angstrom. Use atomic symbols to
+            specify atoms.
+        basis: A string giving the basis set. An example is 'cc-pvtz'.
+            Only optional if loading from file.
+        multiplicity: An integer giving the spin multiplicity.
+        charge: An integer giving the charge.
+
+    Returns:
+        A list of lists of forces as InteractionOperator.
+    """
+
+    # Run electronic structure calculations
+    molecule = run_pyscf(
+                        MolecularData(
+                            geometry, basis, multiplicity, charge,
+                            data_directory=data_directory
+                            ),
+                        forces=True
+                    )
+
+    return molecule.get_nuclear_forces()

--- a/openfermionpyscf/_run_pyscf_test.py
+++ b/openfermionpyscf/_run_pyscf_test.py
@@ -12,19 +12,30 @@
 
 import openfermion
 import openfermionpyscf
+import tempfile
+
+data_dir = tempfile.mkdtemp(prefix="openfermionpyscf_test")
+geometry = [('Li', (0., 0., 0.)), ('H', (0., 0., 1.4))]
 
 
 def test_load_molecular_hamiltonian():
-    geometry = [('Li', (0., 0., 0.)), ('H', (0., 0., 1.4))]
 
     lih_hamiltonian = openfermionpyscf.generate_molecular_hamiltonian(
-            geometry, 'sto-3g', 1, 0, 2, 2)
+            geometry, 'sto-3g', 1, 0, 2, 2, data_directory=data_dir)
     assert openfermion.count_qubits(lih_hamiltonian) == 4
 
     lih_hamiltonian = openfermionpyscf.generate_molecular_hamiltonian(
-            geometry, 'sto-3g', 1, 0, 2, 3)
+            geometry, 'sto-3g', 1, 0, 2, 3, data_directory=data_dir)
     assert openfermion.count_qubits(lih_hamiltonian) == 6
 
     lih_hamiltonian = openfermionpyscf.generate_molecular_hamiltonian(
-            geometry, 'sto-3g', 1, 0, None, None)
+            geometry, 'sto-3g', 1, 0, None, None, data_directory=data_dir)
     assert openfermion.count_qubits(lih_hamiltonian) == 12
+
+
+def test_nuclear_forces():
+    lih_forces = openfermionpyscf.generate_nuclear_forces(
+            geometry, 'sto-3g', 1, 0, data_directory=data_dir)
+    for atom in lih_forces:
+        for xyz in atom:
+            assert openfermion.count_qubits(xyz) == 12

--- a/openfermionpyscf/tests/_pyscf_molecular_data_test.py
+++ b/openfermionpyscf/tests/_pyscf_molecular_data_test.py
@@ -63,10 +63,11 @@ def test_accessing_rdm():
 
     rdm1 = molecule.fci_one_rdm
     rdm2 = molecule.fci_two_rdm
-    #e_ref = molecule._pyscf_data['fci'].e_tot
+    # e_ref = molecule._pyscf_data['fci'].e_tot
     e_tot = (numpy.einsum('pq,pq', h1, rdm1) +
              numpy.einsum('pqrs,pqrs', h2, rdm2) * .5 + e_core)
     numpy.testing.assert_almost_equal(e_tot, -1.1516827321, 9)
+
 
 def test_ccsd_amps():
     mo = molecule.canonical_orbitals

--- a/openfermionpyscf/tests/_run_pyscf_test.py
+++ b/openfermionpyscf/tests/_run_pyscf_test.py
@@ -17,6 +17,9 @@ from openfermion.chem import MolecularData
 from openfermionpyscf import run_pyscf
 from openfermionpyscf import PyscfMolecularData
 
+import tempfile
+
+data_dir = tempfile.mkdtemp(prefix="openfermionpyscf_test")
 
 geometry = [('H', (0., 0., 0.)), ('H', (0., 0., 0.7414))]
 basis = '6-31g'
@@ -25,7 +28,8 @@ charge = 0
 molecule = MolecularData(geometry,
                          basis,
                          multiplicity,
-                         charge)
+                         charge,
+                         data_directory=data_dir)
 
 
 def test_run_pyscf():
@@ -35,5 +39,7 @@ def test_run_pyscf():
                          run_cisd=True,
                          run_ccsd=True,
                          run_fci=True,
+                         forces=True,
                          verbose=1)
+
     assert isinstance(new_mole, PyscfMolecularData)


### PR DESCRIPTION
Adds all ingredients to get force operators.

I have tried to replicate the way the regular one- and two-body integrals are obtained.
There is a general method to get InteractionOperators and separate member functions in the PyscfMolecularData class for the raw tensors.
Everything gets calculated in pyscf during the run_pyscf call.

During testing I also added functionality to write hdf5 files to a temporary data_directory. I think many people that use system-wide installs on computers where they don't have admin privileges will appreciate that. 